### PR TITLE
Fix differential expression table formatting

### DIFF
--- a/docs/cli_documentation.md
+++ b/docs/cli_documentation.md
@@ -337,7 +337,7 @@ wot trajectory_trends --tmap . --cell_days days.txt \
 
 
 ### Trajectory differential expression ###
-you can compare two ancestor distributions through local enrichment. 
+you can compare two ancestor distributions through local enrichment.
 
 The ancestor distributions can be two tips' or one tip's but at different time point. Now we have different ways to give the score that measures the difference between two distributions. Besides, the `matrix.txt` and `matrix1.txt`  should be the form of the result of trajectory trends.
 ```sh
@@ -345,7 +345,8 @@ wot optimal_local_enrichment --matrix1 matrix.txt \
 (--matrix2 matrix2.txt) --score t_test \
 --comparisons comapre.txt (--gsea C1)
 ```
-When we run the cmd, we can get the file like `timepoint.rnk` or `timepoint1_timepoint2.rnk` including each gene 's score.
+
+When we run the cmd, we can get the file like `timepoint.rnk` or `timepoint1_timepoint2.rnk` including each gene's score.
 
 <table class="table table-hover" style="display: table">
   <thead class="thead-light">
@@ -357,38 +358,28 @@ When we run the cmd, we can get the file like `timepoint.rnk` or `timepoint1_tim
   <tbody>
     <tr>
       <td><b>--matrix1</b></td>
-      <td>A matrix with cells on rows and features, such as
-                        genes or pathways on columns See <a href="#matrix_file">formats</a></td>
-    </tr> 
+      <td>A matrix with cells on rows and features, such as genes or pathways on columns See <a href="#matrix_file">formats</a></td>
+    </tr>
     <tr>
       <td><b>--score</b></td>
-      <td>Method to compute differential gene expression score.
-                        Choices are signal to noise, mean difference, t-test,
-                        and fold change.{s2n,mean_difference,fold_change,t_test}
+      <td>Method to compute differential gene expression score. Choices are signal to noise, mean difference, t-test, and fold change.{s2n,mean_difference,fold_change,t_test}</td>
     </tr>
-           <tr>
+    <tr>
       <td>--matrix2</td>
-      <td>A matrix with cells on rows and features, such as
-                        genes or pathways on columns See <a href="#matrix_file">formats</a></td>
+      <td>A matrix with cells on rows and features, such as genes or pathways on columns See <a href="#matrix_file">formats</a></td>
     </tr>
-          <td>--gsea</td>
-      <td>Run (<a href="http://s
-                        oftware.broadinstitute">GSEA</a> on the specified MSigDB collections.<br/>
-                         H (hallmark gene sets), C1 (positional gene sets),
-                        C2 (curated gene sets), C3 (motif gene sets), C4
-                        (computational gene sets), C5 (GO gene sets), C6
-                        (oncogenic signatures), C7 (immunologic signatures)
+    <tr>
+      <td>--gsea</td>
+      <td>Run <a href="http://software.broadinstitute.org/gsea/index.jsp">GSEA</a> on the specified MSigDB collections.<br/>
+          H (hallmark gene sets), C1 (positional gene sets), C2 (curated gene sets), C3 (motif gene sets),
+          C4 (computational gene sets), C5 (GO gene sets), C6 (oncogenic signatures), C7 (immunologic signatures)
       </td>
     </tr>
-       </tr>
-           <tr>
+    <tr>
       <td>--comparisons</td>
-      <td>Comparisons to generate ranked lists for. By default,
-                        for one matrix signatures are created for all
-                        consecutive timepoints. For two matrices for all
-                        matching timepoints.</td>
+      <td>Comparisons to generate ranked lists for. By default, for one matrix signatures are created for all
+      consecutive timepoints. For two matrices for all matching timepoints.</td>
     </tr>
-
   </tbody>
 </table>
 


### PR DESCRIPTION
Missing / extra *tr* fields were causing Markdown crash, rendering documentation as plain text