### PR TITLE
Replace `is` for `==` when testing equality with literals

### DIFF
--- a/wot/commands/gene_set_scores.py
+++ b/wot/commands/gene_set_scores.py
@@ -53,7 +53,7 @@ def main(argv):
     if args.progress:
         print('Read ' + gene_sets)
 
-    if gs.shape[1] is 0:
+    if gs.shape[1] == 0:
         raise ValueError('No overlap of genes in gene sets and dataset')
     if args.gene_set_filter is not None:
         if os.path.exists(args.gene_set_filter):
@@ -63,7 +63,7 @@ def main(argv):
             set_names = args.gene_set_filter.split(',')
         gs_filter = gs.var.index.isin(set_names)
         gs = gs[:, gs_filter]
-    if gs.shape[1] is 0:
+    if gs.shape[1] == 0:
         raise ValueError('No gene sets')
 
     output_prefix = args.out + '_'

--- a/wot/commands/neighborhood_graph.py
+++ b/wot/commands/neighborhood_graph.py
@@ -56,7 +56,7 @@ def main(argv):
             expr = re.compile(args.gene_filter)
             gene_ids = [e for e in adata.var.index.values if expr.match(e)]
         col_indices = adata.var.index.isin(gene_ids)
-        if np.sum(col_indices) is 0:
+        if np.sum(col_indices) == 0:
             raise ValueError('No genes passed the gene filter')
         adata = adata[:, col_indices]
 

--- a/wot/commands/transition_table.py
+++ b/wot/commands/transition_table.py
@@ -19,7 +19,7 @@ def get_set_id_to_indices(cell_sets, tmap, is_columns):
             indices = np.where(np.isin(tmap.columns, cell_ids))[0]
         else:
             indices = np.where(tmap.index.isin(cell_ids))[0]
-        if len(indices) is 0:
+        if len(indices) == 0:
             print(cell_set_name + ' has zero members in dataset')
         else:
             cell_set_id_to_indices[cell_set_name] = indices


### PR DESCRIPTION
See `literal-comparison (R0123)` on the pylint
[documentation](https://pylint.readthedocs.io/en/latest/technical_reference/features.html)