### PR TITLE
Custom Cost Matrices

### DIFF
--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,67 @@
+import wot.ot
+
+import unittest
+
+import pandas as pd
+import numpy as np
+import anndata
+
+class TestIO(unittest.TestCase):
+    
+    def test_costs_single_tmap(self):
+        #Construct an aritifical adata with 6 cells (3 per day)
+        #and 1000 random genes
+        obs_df = pd.DataFrame(data={'day': [1, 1, 1, 2, 2, 2]})
+        var_df = pd.DataFrame(data=None, index=np.arange(1000))
+        expr_matr = np.random.rand(6, 1000)
+        adata = anndata.AnnData(X=expr_matr, obs=obs_df, var=var_df)
+        
+        #Cells should transport along the diagonal 
+        cost_matrix = np.array([[0, 100, 100],
+                                [100, 0, 100],
+                                [100, 100, 0]])
+
+        #Make an ot_model and transport
+        ot_model = wot.ot.OTModel(adata, epsilon=0.01, lambda1=1, lambda2=50)
+        tmap = ot_model.compute_transport_map(1, 2, cost_matrix=cost_matrix)
+
+        #Check if the transport map is within tolerance
+        expected_tmap = np.array([[1, 0, 0],
+                                [0, 1, 0],
+                                [0, 0, 1]])
+        are_similar = np.allclose(tmap.X, expected_tmap, atol=0.01, rtol=0)
+        
+        self.assertTrue(are_similar)
+        
+    def test_costs_multiple_tmaps(self):
+        #Construct an aritifical adata with 9 cells (3 per day)
+        #and 1000 random genes
+        obs_df = pd.DataFrame(data={'day': [1, 1, 1, 2, 2, 2, 3, 3, 3]})
+        var_df = pd.DataFrame(data=None, index=np.arange(1000))
+        expr_matr = np.random.rand(9, 1000)
+        adata = anndata.AnnData(X=expr_matr, obs=obs_df, var=var_df)
+        
+        #Cells should transport along the diagonal for each timepoint
+        cost_matrix = np.array([[0, 100, 100],
+                                [100, 0, 100],
+                                [100, 100, 0]])
+        cost_matrices = [cost_matrix, cost_matrix]
+        
+        #Make an ot_model and transport
+        ot_model = wot.ot.OTModel(adata, epsilon=0.01, lambda1=1, lambda2=50)
+        ot_model.compute_all_transport_maps(tmap_out='tmaps_out/tmap', cost_matrices=cost_matrices)
+        
+        #Read the transport maps and compare them to expected
+        tmap_1 = anndata.read_h5ad('tmaps_out/tmap_1_2.h5ad')
+        tmap_2 = anndata.read_h5ad('tmaps_out/tmap_2_3.h5ad')
+        
+        #Check if the transport maps are within tolerance
+        expected_tmap = np.array([[1, 0, 0],
+                                [0, 1, 0],
+                                [0, 0, 1]])
+        are_similar_tmap_1 = np.allclose(tmap_1.X, expected_tmap, atol=0.01, rtol=0)
+        are_similar_tmap_2 = np.allclose(tmap_2.X, expected_tmap, atol=0.01, rtol=0)
+        
+        self.assertTrue(are_similar_tmap_1 and are_similar_tmap_2)
+
+        

--- a/wot/ot/ot_model.py
+++ b/wot/ot/ot_model.py
@@ -122,7 +122,7 @@ class OTModel:
         return product(covariate, covariate)
 
     def compute_all_transport_maps(self, tmap_out='tmaps', overwrite=True, output_file_format='h5ad',
-                                   with_covariates=False):
+                                   with_covariates=False, cost_matrices=None):
         """
         Computes all required transport maps.
 
@@ -136,6 +136,8 @@ class OTModel:
             Transport map file format
         with_covariates : bool, optional, default : False
             Compute all covariate-restricted transport maps as well
+        cost_matrices: list of ndarray, optional, default : None
+            Custom cost matrices to use in transport. None to skip.
 
         Returns
         -------
@@ -170,10 +172,14 @@ class OTModel:
         if not day_pairs:
             logger.info('No day pairs')
             return
-
+        
+        #Check if we aren't custom cost matrices
+        if cost_matrices is None:
+            cost_matrices = [None for day_pair in day_pairs]
+            
         full_learned_growth_df = None
         save_learned_growth = self.ot_config.get('growth_iters', 1) > 1
-        for day_pair in day_pairs:
+        for day_pair, cost_matrix in zip(day_pairs, cost_matrices):
             path = tmap_prefix
             if not with_covariates:
                 path += "_{}_{}".format(*day_pair)
@@ -185,7 +191,7 @@ class OTModel:
                 logger.info('Found existing tmap at ' + output_file + '. ')
                 continue
 
-            tmap = self.compute_transport_map(*day_pair)
+            tmap = self.compute_transport_map(*day_pair, cost_matrix=cost_matrix)
             wot.io.write_dataset(tmap, output_file, output_format=output_file_format)
             if save_learned_growth:
                 learned_growth_df = tmap.obs

--- a/wot/ot/ot_model.py
+++ b/wot/ot/ot_model.py
@@ -262,6 +262,7 @@ class OTModel:
             Configuration to use for all parameters for the couplings :
             - t0, t1
             - lambda1, lambda2, epsilon, g
+            - C
         """
 
         import gc
@@ -307,6 +308,7 @@ class OTModel:
             C = OTModel.compute_default_cost_matrix(p0_x, p1_x, eigenvals)
             config['C'] = C
         
+        C = config['C']
         delta_days = t1 - t0
 
         if self.cell_growth_rate_field in p0.obs.columns:


### PR DESCRIPTION
These changes allow users to specify custom cost matrices to be used during transport. Use cases for this might include incorporating RNA velocity into the cost, or using a different norm to calculate cost. This change may also make #78 easier.