### PR TITLE
Differential expression across different timepoints and fates forward in time

### DIFF
--- a/wot/tmap/util.py
+++ b/wot/tmap/util.py
@@ -7,6 +7,8 @@ import scipy.sparse
 
 
 def generate_comparisons(comparison_names, compare, days, reference_day='start'):
+    if compare == "all_times":
+        return itertools.product([(name, name) for name in comparison_names], itertools.combinations(days, 2))
     if compare != 'within':  # within, match, all, or trajectory name
         if compare == 'all':
             comparisons = itertools.combinations(comparison_names, 2)


### PR DESCRIPTION
- Run diff exp across different timepoints, for the same group of cells. Add a parameter to compare all combinations of timepoints.
Example:
```
generate_comparisons(["A","B"], "all_times", [1,2,3,4]):
[(('A','A',),(1,2)),
(('A','A',),(1,3)),
(('A','A',),(1,4)),
(('A','A',),(2,3)),
(('A','A',),(2,4)),
(('A','A',),(3,4)),
(('B','B',),(1,2)),
(('B','B',),(1,3)),
(('B','B',),(1,4)),
(('B','B',),(2,3)),
(('B','B',),(2,4)),
(('B','B',),(3,4))]
```
- Compute fates forward in time: Add flag to also compute fates forward in time.
