### PR TITLE
Updated anndata.read with anndata.read_h5ad

### DIFF
--- a/wot/commands/util.py
+++ b/wot/commands/util.py
@@ -45,7 +45,7 @@ def run_trajectory_or_fates(args, fates):
     else:
         import anndata  # h5ad#obs
         tokens = args.cell_set.split('#')
-        adata = anndata.read(tokens[0], backed='r')
+        adata = anndata.read_h5ad(tokens[0], backed='r')
         cell_sets = adata.obs.groupby(tokens[1]).groups
     if args.cell_set_filter is not None:
         valid_cell_sets = args.cell_set_filter.split(',')
@@ -79,7 +79,7 @@ def run_trajectory_or_fates(args, fates):
         else:
             import anndata  # h5ad#obsm
             tokens = embedding_file.split('#')
-            adata = anndata.read(tokens[0], backed='r')
+            adata = anndata.read_h5ad(tokens[0], backed='r')
             m = adata.obsm[tokens[1]]
             full_embedding_df = pd.DataFrame(index=adata.obs.index, data=(dict(x=m[:, 0], y=m[:, 1])))
         xrange = full_embedding_df['x'].min(), full_embedding_df['x'].max()

--- a/wot/io/io.py
+++ b/wot/io/io.py
@@ -401,7 +401,7 @@ def read_dataset(path, obs=None, var=None, obs_filter=None, var_filter=None, **k
         df = pd.read_csv(path, engine='python', header=0, sep=None, index_col=0)
         adata = anndata.AnnData(X=df.values, obs=pd.DataFrame(index=df.index), var=pd.DataFrame(index=df.columns))
     elif ext == '.h5ad':
-        adata = anndata.read(path)
+        adata = anndata.read_h5ad(path)
     elif ext == '.loom':
         adata = anndata.read_loom(path)
     elif ext == '.mtx':


### PR DESCRIPTION
anndata.read was removed a few versions ago, so wot is broken when used on modern versions of python. This fixes by simply changing to anndata.read_h5ad. This should also be backwards compatible. This fixes issue #111 .